### PR TITLE
Adds plugin to display the top 50 players of the server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -142,3 +142,4 @@ userdata/schemas/*
 !userdata/migrations/.gitkeep
 !userdata/plugins/.gitkeep
 docker-compose.yml
+userdata/seed.sql

--- a/core/plugins/topPlayers/index.ts
+++ b/core/plugins/topPlayers/index.ts
@@ -1,0 +1,117 @@
+import Score from "@core/schemas/scores.model";
+import Plugin from "../index";
+import Player from "@core/schemas/players.model";
+import ListWindow from "@core/ui/listwindow";
+
+interface RankingMap {
+    [key: string]: number
+}
+
+export default class TopPlayers extends Plugin {
+    static depends: string[] = ["records"];
+    topPlayersCache!: [string, number][] | null;
+    topPlayersCacheTime!: Date | null;
+
+    async onLoad() {
+        
+        //tmc.addCommand("//top50", this.getTopPlayers.bind(this), "Get top 50 players of the server.");
+    }
+
+    async onStart(): Promise<void> {
+        this.cmdTop50("mery");
+    }
+
+    async onUnload() {
+        tmc.removeCommand("//top50");
+    }
+
+    async cmdTop50(login: string) {
+        const msg = "¤info¤Loading Top 50 players of the server...";
+        tmc.chat(msg, login);
+        tmc.cli(msg);
+        const ranking = await this.getTopPlayers(50);
+        if(!ranking) {
+            tmc.chat("No ranking yet.", login);
+            tmc.cli("No ranking yet.");
+            return;
+        }
+
+        let formattedRanking = [];
+        for (let player of ranking) {
+            formattedRanking.push(
+                {
+                    rank: player[1],
+                    nickname: player[0],
+                });
+        }
+
+        console.log(formattedRanking);
+        
+        const window = new ListWindow(login);
+        window.size = { width: 90, height: 95 };
+        window.title = "Top 50 Players of this server [" + formattedRanking.length + "]";
+        window.setItems(formattedRanking);
+        window.setColumns([
+            { key: "rank", title: "Rank", width: 10 },
+            { key: "nickname", title: "Nickname", width: 50 },
+        ]);
+        await window.display();
+    }
+
+    async getTopPlayers(maxPlayers: number) {
+        if (!("records" in tmc.plugins)) {
+            return null;
+        }
+
+        const now = new Date().getTime();
+        const diff = this.topPlayersCacheTime ? Math.floor((now - this.topPlayersCacheTime.getTime()) / 1000) : null;
+
+        // Picks in cache if it has been less than 60 seconds since the last command usage.
+        if (!this.topPlayersCache || !diff || diff > 60) {
+            this.topPlayersCache = null;
+            this.topPlayersCacheTime = null;
+        } else {
+            return this.topPlayersCache;
+        }
+
+        const maps = tmc.maps.getMaplist();
+        let players: RankingMap = {};
+
+        for (const map of maps) {
+            // Fetches the records of the map.
+            const records = await Score.findAll({
+                where: {
+                    mapUuid: map.UId
+                },
+                include: [Player],
+                limit: maxPlayers,
+
+            });
+
+            // Count records.
+            const count = records.length;
+
+            // Updates the ranking with the record rank for each player.
+            for (const record of records) {
+                if (record.player) {
+                    if (!(record.player.nickname! in players)) {
+                        players[record.player.nickname!] = 0
+                    }
+                    // Convert rank position into points.
+                    players[record.player.nickname!] += (count - record.rank!);
+                }
+            }
+        }
+
+        // Sorts the points by decending order.
+        let sortedRanking = Object.entries(players).sort(([, a], [, b]) => b - a);
+        // Assigns the new ranks for the players.
+        let i = 0;
+        sortedRanking.forEach((value) => value[1] = i + 1);
+
+        this.topPlayersCache = sortedRanking
+        this.topPlayersCacheTime = new Date();
+        return this.topPlayersCache;
+    }
+}
+

--- a/core/plugins/topPlayers/index.ts
+++ b/core/plugins/topPlayers/index.ts
@@ -41,7 +41,7 @@ export default class TopPlayers extends Plugin {
         }
 
         const window = new ListWindow(login);
-        window.size = { width: 50, height: 95 };
+        window.size = { width: 70, height: 95 };
         window.title = "Top 50 Players of this server [" + formattedRanking.length + "]";
         window.setItems(formattedRanking);
         window.setColumns([

--- a/core/plugins/topPlayers/index.ts
+++ b/core/plugins/topPlayers/index.ts
@@ -13,16 +13,11 @@ export default class TopPlayers extends Plugin {
     topPlayersCacheTime!: Date | null;
 
     async onLoad() {
-        
-        //tmc.addCommand("//top50", this.getTopPlayers.bind(this), "Get top 50 players of the server.");
-    }
-
-    async onStart(): Promise<void> {
-        this.cmdTop50("mery");
+        tmc.addCommand("/top50", this.cmdTop50.bind(this), "Get top 50 players of the server.");
     }
 
     async onUnload() {
-        tmc.removeCommand("//top50");
+        tmc.removeCommand("/top50");
     }
 
     async cmdTop50(login: string) {
@@ -30,7 +25,7 @@ export default class TopPlayers extends Plugin {
         tmc.chat(msg, login);
         tmc.cli(msg);
         const ranking = await this.getTopPlayers(50);
-        if(!ranking) {
+        if (!ranking) {
             tmc.chat("No ranking yet.", login);
             tmc.cli("No ranking yet.");
             return;
@@ -46,7 +41,7 @@ export default class TopPlayers extends Plugin {
         }
 
         console.log(formattedRanking);
-        
+
         const window = new ListWindow(login);
         window.size = { width: 90, height: 95 };
         window.title = "Top 50 Players of this server [" + formattedRanking.length + "]";
@@ -83,7 +78,7 @@ export default class TopPlayers extends Plugin {
                 where: {
                     mapUuid: map.UId
                 },
-                include: [Player],
+                include: { model: Player, attributes: ['nickname'] },
                 limit: maxPlayers,
 
             });


### PR DESCRIPTION
The plugin fetches the records of the maps list by ascending order on time attribute.
It assigns rank to each player.
It calculates the points of each player with (recordsCount - rank) + 1 and adds it to the points amount of the player.
Then, we calculates averages by dividing these points by the maps count and sorts the array by descending order.
Finally we attribuate a final rank to each player in the array and we have our ranking for the server.
